### PR TITLE
Before after hooks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp22"
-version = "0.2.1"
+version = "0.3.1"
 edition = "2021"
 authors = ["Cardinal"]
 homepage = "https://github.com/Cardinal-Cryptography/PSP22"

--- a/README.md
+++ b/README.md
@@ -185,7 +185,6 @@ impl PSP22Burnable for Token {
 }
 ```
 
-
 [lib]: ./lib.rs
 [traits]: ./traits.rs
 [ink]: https://use.ink

--- a/data.rs
+++ b/data.rs
@@ -48,25 +48,26 @@ impl<T> PSP22Hooks for T
 where
     T: HasPSP22Data,
 {
+    /// Checks whether the caller has enough allowance to burn `value` amount of tokens from the `owner`
     fn before_burn(
         &self,
         caller: AccountId,
-        from: AccountId,
+        owner: AccountId,
         value: u128,
     ) -> Result<(), PSP22Error> {
-        if self.data().allowance(from, caller) < value {
+        if self.data().allowance(owner, caller) < value {
             return Err(PSP22Error::InsufficientAllowance);
         }
         Ok(())
     }
-
+    /// Reduces the caller's allowance on behlaf of the `owner` by the burnt `value` amount of tokens
     fn after_burn(
         &mut self,
         caller: AccountId,
-        from: AccountId,
+        owner: AccountId,
         value: u128,
     ) -> Result<(), PSP22Error> {
-        self.data_mut().decrease_allowance(from, caller, value)?;
+        self.data_mut().decrease_allowance(owner, caller, value)?;
         Ok(())
     }
 }
@@ -206,7 +207,7 @@ impl PSP22Data {
         }])
     }
 
-    /// Increases the allowance granted  by `owner` to `spender` by `delta_value`.
+    /// Increases the allowance granted by `owner` to `spender` by `delta_value`.
     pub fn increase_allowance(
         &mut self,
         owner: AccountId,
@@ -226,7 +227,7 @@ impl PSP22Data {
         }])
     }
 
-    /// Decreases the allowance granted  by `owner` to `spender` by `delta_value`.
+    /// Decreases the allowance granted by `owner` to `spender` by `delta_value`.
     pub fn decrease_allowance(
         &mut self,
         owner: AccountId,

--- a/lib.rs
+++ b/lib.rs
@@ -7,7 +7,7 @@ mod traits;
 
 pub use data::{PSP22Data, PSP22Event};
 pub use errors::PSP22Error;
-pub use traits::{PSP22Burnable, PSP22Metadata, PSP22Mintable, PSP22};
+pub use traits::{HasPSP22Data, PSP22Burnable, PSP22Hooks, PSP22Metadata, PSP22Mintable, PSP22};
 
 // An example code of a smart contract using PSP22Data struct to implement
 // the functionality of PSP22 fungible token.

--- a/traits.rs
+++ b/traits.rs
@@ -3,7 +3,7 @@ use ink::{
     primitives::AccountId,
 };
 
-use crate::errors::PSP22Error;
+use crate::{errors::PSP22Error, PSP22Data};
 
 #[ink::trait_definition]
 pub trait PSP22 {
@@ -188,4 +188,25 @@ pub trait PSP22Mintable {
     /// `value` exceeds maximal value of `u128` type.
     #[ink(message)]
     fn mint(&mut self, to: AccountId, value: u128) -> Result<(), PSP22Error>;
+}
+
+pub trait HasPSP22Data {
+    fn data(&self) -> &PSP22Data;
+    fn data_mut(&mut self) -> &mut PSP22Data;
+}
+
+pub trait PSP22Hooks {
+    fn before_burn(
+        &self,
+        caller: AccountId,
+        _from: AccountId,
+        _value: u128,
+    ) -> Result<(), PSP22Error>;
+
+    fn after_burn(
+        &mut self,
+        caller: AccountId,
+        _from: AccountId,
+        _value: u128,
+    ) -> Result<(), PSP22Error>;
 }

--- a/traits.rs
+++ b/traits.rs
@@ -138,9 +138,24 @@ pub trait PSP22Metadata {
 
 #[ink::trait_definition]
 pub trait PSP22Burnable {
-    /// Burns `value` tokens from the senders account.
+    /// Burns `value` tokens from the senders account, reducing the total supply
     ///
     /// The selector for this message is `0x7a9da510` (first 4 bytes of `blake2b_256("PSP22Burnable::burn")`).
+    ///
+    /// # Events
+    ///
+    /// On success a `Transfer` event is emitted with `None` recipient.
+    ///
+    /// No-op if `amount` is zero, returns success and no events are emitted.
+    ///
+    /// # Errors
+    ///
+    /// Reverts with `InsufficientBalance` if the `amount` exceeds the caller's balance.
+    #[ink(message)]
+    fn burn(&mut self, value: u128) -> Result<(), PSP22Error>;
+
+    /// Burns `value` tokens from account, reducing the total supply. Value is then deducted from the caller’s allowance.
+    /// The selector for this message is `0xTODO` (first 4 bytes of `blake2b_256("PSP22Burnable::burn_from")`).
     ///
     /// # Events
     ///
@@ -152,12 +167,12 @@ pub trait PSP22Burnable {
     ///
     /// Reverts with `InsufficientBalance` if the `value` exceeds the caller's balance.
     #[ink(message)]
-    fn burn(&mut self, value: u128) -> Result<(), PSP22Error>;
+    fn burn_from(&mut self, from: AccountId, value: u128) -> Result<(), PSP22Error>;
 }
 
 #[ink::trait_definition]
 pub trait PSP22Mintable {
-    /// Mints `value` tokens to the senders account.
+    /// Mints `value` tokens to the `to` account.
     ///
     /// The selector for this message is `0xfc3c75d4` (first 4 bytes of `blake2b_256("PSP22Mintable::mint")`).
     ///
@@ -172,5 +187,5 @@ pub trait PSP22Mintable {
     /// Reverts with `Custom (max supply exceeded)` if the total supply increased by
     /// `value` exceeds maximal value of `u128` type.
     #[ink(message)]
-    fn mint(&mut self, value: u128) -> Result<(), PSP22Error>;
+    fn mint(&mut self, to: AccountId, value: u128) -> Result<(), PSP22Error>;
 }

--- a/traits.rs
+++ b/traits.rs
@@ -155,7 +155,7 @@ pub trait PSP22Burnable {
     fn burn(&mut self, value: u128) -> Result<(), PSP22Error>;
 
     /// Burns `value` tokens from account, reducing the total supply. Value is then deducted from the caller’s allowance.
-    /// The selector for this message is `0xTODO` (first 4 bytes of `blake2b_256("PSP22Burnable::burn_from")`).
+    /// The selector for this message is `0x1d3e58b5` (first 4 bytes of `blake2b_256("PSP22Burnable::burn_from")`).
     ///
     /// # Events
     ///

--- a/traits.rs
+++ b/traits.rs
@@ -196,17 +196,35 @@ pub trait HasPSP22Data {
 }
 
 pub trait PSP22Hooks {
+    /// Checks whether the caller has enough allowance to burn `value` amount of tokens from the `owner`
+    ///
+    /// # Errors
+    ///
+    /// Reverts with `InsufficientAllowance` error if value exceed the caller's allowance
     fn before_burn(
         &self,
         caller: AccountId,
-        _from: AccountId,
-        _value: u128,
+        owner: AccountId,
+        value: u128,
     ) -> Result<(), PSP22Error>;
 
+    /// Decreases the allowance granted by the `owner` to the `caller` by the `value`.
+    ///
+    /// A no-op if the caller and the `spender` address is the same or if `value` is zero, in which case
+    /// returns success and no events are emitted.
+    ///
+    /// # Events
+    ///
+    /// An `Approval` event with the new allowance amount is emitted.
+    ///
+    ///
+    /// # Errors
+    ///
+    /// Reverts with `InsufficientAllowance` the `value` exceeds the allowance granted by the `owner` to the `caller`.
     fn after_burn(
         &mut self,
         caller: AccountId,
-        _from: AccountId,
-        _value: u128,
+        owner: AccountId,
+        value: u128,
     ) -> Result<(), PSP22Error>;
 }


### PR DESCRIPTION
This PR introduces two extensions:

- in addition to the `burn` that allows burning own tokens it adds a `burn_from` tx, modelled after the [ERC20Burnable](https://docs.openzeppelin.com/contracts/2.x/api/token/erc20#ERC20Burnable) standard,  it allows for burning tokens on behalf of the owner
- addition of the optional `Hooks` blanket trait (for all tokens that implement HasPSP22Data), which provides `before_burn` and `after_burn` hooks to check and modify allowance when burning tokens on behalf of the owner