### PR TITLE
Add traits and function implementations for missing extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+.idea

--- a/errors.rs
+++ b/errors.rs
@@ -16,3 +16,12 @@ pub enum PSP22Error {
     /// Returned if a safe transfer check failed [deprecated].
     SafeTransferCheckFailed(String),
 }
+
+/// Errors related to ownership operations.
+///
+/// This enum is used for managing errors that occur in ownership-related
+/// functionalities.
+#[derive(Debug, PartialEq, Eq, scale::Encode, scale::Decode)]
+#[cfg_attr(feature = "std", derive(scale_info::TypeInfo))]
+pub enum OwnableError {
+}

--- a/traits.rs
+++ b/traits.rs
@@ -4,6 +4,7 @@ use ink::{
 };
 
 use crate::errors::PSP22Error;
+use crate::errors::OwnableError;
 
 #[ink::trait_definition]
 pub trait PSP22 {
@@ -153,6 +154,23 @@ pub trait PSP22Burnable {
     /// Reverts with `InsufficientBalance` if the `value` exceeds the caller's balance.
     #[ink(message)]
     fn burn(&mut self, value: u128) -> Result<(), PSP22Error>;
+
+    /// Burns `value` tokens from the "account" account id. Spends allowances.
+    ///
+    /// The selector for this message are
+    /// first 4 bytes of `blake2b_256("PSP22Burnable::burn_from")`
+    ///
+    /// # Events
+    ///
+    /// On success a `Transfer` event is emitted with `None` recipient.
+    ///
+    /// No-op if `value` is zero, returns success and no events are emitted.
+    ///
+    /// # Errors
+    ///
+    /// Reverts with `InsufficientBalance` if the `value` exceeds the caller's balance.
+    #[ink(message)]
+    fn burn_from(&mut self, account: AccountId, value: u128) -> Result<(), PSP22Error>;
 }
 
 #[ink::trait_definition]
@@ -172,5 +190,109 @@ pub trait PSP22Mintable {
     /// Reverts with `Custom (max supply exceeded)` if the total supply increased by
     /// `value` exceeds maximal value of `u128` type.
     #[ink(message)]
-    fn mint(&mut self, value: u128) -> Result<(), PSP22Error>;
+    fn mint(&mut self, to: AccountId, value: u128) -> Result<(), PSP22Error>;
+}
+
+
+/// Trait for pausing and unpausing token transfers.
+///
+/// This trait allows the contract owner to pause or unpause token transfers,
+/// which can be useful in emergency situations or during maintenance.
+#[ink::trait_definition]
+pub trait PSP22Pausable {
+    /// Pauses all token transfers.
+    ///
+    /// This method is used to temporarily halt all transfer operations.
+    ///
+    /// # Returns
+    ///
+    /// A `Result<(), PSP22Error>` indicating whether the operation was successful.
+    #[ink(message)]
+    fn pause(&mut self) -> Result<(), PSP22Error>;
+
+    /// Unpauses all token transfers.
+    ///
+    /// This method re-enables token transfer operations.
+    ///
+    /// # Returns
+    ///
+    /// A `Result<(), PSP22Error>` indicating whether the operation was successful.
+    #[ink(message)]
+    fn unpause(&mut self) -> Result<(), PSP22Error>;
+}
+
+/// Trait for wrapping and unwrapping PSP22 tokens.
+///
+/// This trait provides methods for depositing and withdrawing tokens,
+/// often used in implementations that wrap other token standards.
+#[ink::trait_definition]
+pub trait PSP22Wrapper {
+    /// Deposits tokens into the contract for a specified account.
+    ///
+    /// This method allows a user to add tokens to the contract, which can be used
+    /// for various functionalities like staking or liquidity provision.
+    ///
+    /// # Arguments
+    ///
+    /// * `account` - The account for which the tokens will be deposited.
+    /// * `amount` - The amount of tokens to deposit.
+    ///
+    /// # Returns
+    ///
+    /// A `Result<(), PSP22Error>` indicating the success or failure of the operation.
+    #[ink(message)]
+    fn deposit_for(&mut self, account: AccountId, amount: u128) -> Result<(), PSP22Error>;
+
+    /// Withdraws tokens from the contract to a specified account.
+    ///
+    /// This method allows users to withdraw their tokens from the contract.
+    ///
+    /// # Arguments
+    ///
+    /// * `account` - The account to which the tokens will be withdrawn.
+    /// * `amount` - The amount of tokens to withdraw.
+    ///
+    /// # Returns
+    ///
+    /// A `Result<(), PSP22Error>` indicating the success or failure of the operation.
+    #[ink(message)]
+    fn withdraw_to(&mut self, account: AccountId, amount: u128) -> Result<(), PSP22Error>;
+}
+
+/// Trait for ownership-related functionalities.
+///
+/// Provides methods for managing ownership of the contract, including
+/// transferring and renouncing ownership.
+#[ink::trait_definition]
+pub trait Ownable {
+    /// Returns the address of the current owner.
+    ///
+    /// # Returns
+    ///
+    /// The `AccountId` of the current owner.
+    #[ink(message)]
+    fn owner(&self) -> Option<AccountId>;
+
+    /// Renounces ownership of the contract.
+    ///
+    /// This method is used to permanently transfer control of the contract
+    /// away from the current owner, leaving it without an owner.
+    ///
+    /// # Returns
+    ///
+    /// A `Result<(), OwnableError>` indicating whether the operation was successful.
+    #[ink(message)]
+    fn renounce_ownership(&mut self) -> Result<(), OwnableError>;
+
+    /// Transfers ownership of the contract to a new account.
+    ///
+    /// # Arguments
+    ///
+    /// * `new_owner` - The `AccountId` of the new owner.
+    ///
+    /// # Returns
+    ///
+    /// A `Result<(), OwnableError>` indicating whether the operation was successful.
+    #[ink(message)]
+    fn transfer_ownership(&mut self, new_owner: Option<AccountId>) -> Result<(), OwnableError>;
 }


### PR DESCRIPTION
Added implementations for missing extensions.

Traits added:
*  PSP22Pausable
    * `fn pause(&mut self)`
    * `fn unpause(&mut self)`
* PSP22Wrapper
    * `fn deposit_for(&mut self, account: AccountId, amount: u128)`
    * `fn withdraw_to(&mut self, account: AccountId, amount: u128)`
* Ownable
    * `fn owner(&self)`
    * `fn renounce_ownership(&mut self)`
    * `fn transfer_ownership(&mut self, new_owner: Option<AccountId>)`
    
Traits modified:
* PSP22
    * Added `fn burn_from(&mut self, account: AccountId, value: u128)`
* PSP22Mintable
    * Changed `mint` to `fn mint(&mut self, to: AccountId, value: u128)` 
    
Added error enum - `OwnableError`

Added function implementations for:
* `burn_from`
* `deposit`
* `withdraw`

Example lib.rs implementation that contains all extensions enabled can be found here: https://gist.github.com/coredumped7893/38ea06963de8c5034b58a9267be50758


Code is based on this version of the psp22: https://github.com/Smart-Beaver/smart-contracts/tree/main/PSP22