### PR TITLE
Emit Transfer event in the constructor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp22"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = ["Cardinal"]
 homepage = "https://github.com/Cardinal-Cryptography/PSP22"

--- a/data.rs
+++ b/data.rs
@@ -45,14 +45,23 @@ pub struct PSP22Data {
 
 impl PSP22Data {
     /// Creates a token with `supply` balance, initially held by the `creator` account.
-    pub fn new(supply: u128, creator: AccountId) -> PSP22Data {
+    pub fn new(supply: u128, creator: AccountId) -> (PSP22Data, Vec<PSP22Event>) {
         let mut data = PSP22Data {
             total_supply: supply,
             balances: Default::default(),
             allowances: Default::default(),
         };
         data.balances.insert(creator, &supply);
-        data
+        let events = if supply > 0 {
+            vec![PSP22Event::Transfer {
+                from: None,
+                to: Some(creator),
+                value: supply,
+            }]
+        } else {
+            vec![]
+        };
+        (data, events)
     }
 
     pub fn total_supply(&self) -> u128 {

--- a/lib.rs
+++ b/lib.rs
@@ -43,8 +43,10 @@ mod token {
             symbol: Option<String>,
             decimals: u8,
         ) -> Self {
+            let (data, events) = PSP22Data::new(supply, Self::env().caller()); // (2)
+            Self::emit_events(events);
             Self {
-                data: PSP22Data::new(supply, Self::env().caller()), // (2)
+                data,
                 name,
                 symbol,
                 decimals,
@@ -54,17 +56,17 @@ mod token {
         // A helper function translating a vector of PSP22Events into the proper
         // ink event types (defined internally in this contract) and emitting them.
         // (5)
-        fn emit_events(&self, events: Vec<PSP22Event>) {
+        fn emit_events(events: Vec<PSP22Event>) {
             for event in events {
                 match event {
                     PSP22Event::Transfer { from, to, value } => {
-                        self.env().emit_event(Transfer { from, to, value })
+                        Self::env().emit_event(Transfer { from, to, value })
                     }
                     PSP22Event::Approval {
                         owner,
                         spender,
                         amount,
-                    } => self.env().emit_event(Approval {
+                    } => Self::env().emit_event(Approval {
                         owner,
                         spender,
                         amount,
@@ -119,7 +121,7 @@ mod token {
             _data: Vec<u8>,
         ) -> Result<(), PSP22Error> {
             let events = self.data.transfer(self.env().caller(), to, value)?;
-            self.emit_events(events);
+            Self::emit_events(events);
             Ok(())
         }
 
@@ -134,14 +136,14 @@ mod token {
             let events = self
                 .data
                 .transfer_from(self.env().caller(), from, to, value)?;
-            self.emit_events(events);
+            Self::emit_events(events);
             Ok(())
         }
 
         #[ink(message)]
         fn approve(&mut self, spender: AccountId, value: u128) -> Result<(), PSP22Error> {
             let events = self.data.approve(self.env().caller(), spender, value)?;
-            self.emit_events(events);
+            Self::emit_events(events);
             Ok(())
         }
 
@@ -154,7 +156,7 @@ mod token {
             let events = self
                 .data
                 .increase_allowance(self.env().caller(), spender, delta_value)?;
-            self.emit_events(events);
+            Self::emit_events(events);
             Ok(())
         }
 
@@ -167,7 +169,7 @@ mod token {
             let events = self
                 .data
                 .decrease_allowance(self.env().caller(), spender, delta_value)?;
-            self.emit_events(events);
+            Self::emit_events(events);
             Ok(())
         }
     }

--- a/testing.rs
+++ b/testing.rs
@@ -57,7 +57,19 @@ macro_rules! tests {
                 let acc = default_accounts::<E>();
                 set_caller::<E>(acc.alice);
                 let supply = 1000;
+
+                // Constructor should emit a single Transfer event
+                let start = recorded_events().count();
                 let token = $constructor(supply);
+                let events = decode_events(start);
+                assert_eq!(events.len(), 1);
+                if let Event::Transfer(Transfer { from, to, value }) = events[0] {
+                    assert_eq!(from, None, "Should set 'from=None'");
+                    assert_eq!(to, Some(acc.alice), "Should set 'to=caller'");
+                    assert_eq!(value, supply, "Should set 'value=supply'");
+                } else {
+                    panic!("Event is not Transfer")
+                }
 
                 assert_eq!(token.total_supply(), supply);
                 assert_eq!(token.balance_of(acc.alice), supply);


### PR DESCRIPTION
I should have bumped minor version but there's already 0.3.0 in `main` that migrated the contracts to ink!5.