### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The contents of this repository can be used in following ways:
 
 The file [`lib.rs`][lib] contains a ready to use implementation of basic PSP22 token contract (extended with PSP22Metadata). To use it, please check out this repository and compile its contents using [`cargo-contract`][cargo-contract] with the `"contract"` feature enabled:
 ```
-$ cargo contract build --release --features "contract"
+cargo contract build --release --features "contract"
 ```
 ### 2. Cross contract calling with traits
 


### PR DESCRIPTION
It's just that `$` gets copied on line 20 which we don't need..

Better it be -> `cargo contract build --release --features "contract"`