### PR TITLE
Make "contract" feature a default for easier compilation

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -38,7 +38,6 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --features "contract"
 
   build:
     name: Build the contract
@@ -68,4 +67,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: contract
-          args: build --release --features "contract"
+          args: build --release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ ink = { version = "5.0.0", default-features = false }
 path = "lib.rs"
 
 [features]
-default = ["std"]
+default = ["std", "contract"]
 std = ["ink/std"]
 contract = []
 ink-as-dependency = []

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ The contents of this repository can be used in following ways:
 
 ### 1. Ready to use contract
 
-The file [`lib.rs`][lib] contains a ready to use implementation of basic PSP22 token contract (extended with PSP22Metadata). To use it, please check out this repository and compile its contents using [`cargo-contract`][cargo-contract] with the `"contract"` feature enabled:
+The file [`lib.rs`][lib] contains a ready to use implementation of basic PSP22 token contract (extended with PSP22Metadata). To use it, please check out this repository and compile its contents using [`cargo-contract`][cargo-contract]:
 ```bash
-cargo contract build --release --features "contract"
+cargo contract build --release
 ```
 ### 2. Cross contract calling with traits
 
@@ -26,7 +26,7 @@ The `PSP22` trait contains all the methods defined in the PSP22 standard. The tr
 In your contract, if you would like to make a call to some other contract implementing the PSP22 standard, all you need to do is:
 ```rust
 use ink::contract_ref;
-use ink::prelude::vec::vec;
+use ink::prelude::vec;
 use psp22::PSP22;
 
 let mut token: contract_ref!(PSP22) = other_contract_address.into();

--- a/testing.rs
+++ b/testing.rs
@@ -6,6 +6,7 @@
 #[macro_export]
 macro_rules! tests {
     ($contract:ident, $constructor:expr) => {
+        #[allow(clippy::redundant_closure_call)]
         mod psp22_unit_tests {
             use super::*;
             use ink::env::test::*;


### PR DESCRIPTION
Motivation: in some verifiable build scenarios the contract must be compiled with plain `cargo contract build --release` with no possibility to pass arguments. This PR makes the default PSP22 contract compatible with that